### PR TITLE
Supple doller after rounds

### DIFF
--- a/common/salt.go
+++ b/common/salt.go
@@ -96,7 +96,7 @@ func (s *Salt) GenerateWRounds(length, rounds int) []byte {
 
 	roundsText := ""
 	if rounds != s.RoundsDefault {
-		roundsText = roundsPrefix + strconv.Itoa(rounds)
+		roundsText = roundsPrefix + strconv.Itoa(rounds) + "$"
 	}
 
 	out := make([]byte, len(s.MagicPrefix)+len(roundsText)+length)

--- a/common/salt_test.go
+++ b/common/salt_test.go
@@ -4,12 +4,19 @@
 
 package common
 
-import "testing"
+import (
+	"testing"
+	"fmt"
+	"strings"
+)
 
 var _Salt = &Salt{
 	MagicPrefix: []byte("$foo$"),
 	SaltLenMin:  1,
 	SaltLenMax:  8,
+	RoundsDefault: 5,
+	RoundsMin: 1,
+	RoundsMax: 10,
 }
 
 func TestGenerateSalt(t *testing.T) {
@@ -28,5 +35,15 @@ func TestGenerateSalt(t *testing.T) {
 	salt = _Salt.Generate(9)
 	if len(salt) != len(_Salt.MagicPrefix)+8 {
 		t.Errorf("Expected len 8, got len %d", len(salt))
+	}
+}
+
+func TestGenerateSaltWRounds(t *testing.T) {
+	rounds := 7
+	expectPrefix := fmt.Sprintf("%srounds=%d$", _Salt.MagicPrefix, 7)
+
+	salt := _Salt.GenerateWRounds(10, rounds)
+	if !strings.HasPrefix(string(salt), expectPrefix) {
+		t.Errorf("Expected it has prefix \"%s\", but missing it", expectPrefix)
 	}
 }


### PR DESCRIPTION
Now got `$6$rounds=100000bp1H7IqCOq9vkzXj` or something like that, by `crypt.Salt#GenerateWRonuds`.

I assume missing `$` after `rounds=xxxx` is bug and fixed it.