### PR TITLE
[Security] Use constant-time comparisons for hashes

### DIFF
--- a/md5_crypt/md5_crypt.go
+++ b/md5_crypt/md5_crypt.go
@@ -9,6 +9,7 @@ package md5_crypt
 import (
 	"bytes"
 	"crypto/md5"
+	"crypto/subtle"
 
 	"github.com/GehirnInc/crypt"
 	"github.com/GehirnInc/crypt/common"
@@ -131,7 +132,7 @@ func (c *crypter) Verify(hashedKey string, key []byte) error {
 	if err != nil {
 		return err
 	}
-	if newHash != hashedKey {
+	if subtle.ConstantTimeCompare([]byte(newHash), []byte(hashedKey)) != 1 {
 		return crypt.ErrKeyMismatch
 	}
 	return nil

--- a/sha256_crypt/sha256_crypt.go
+++ b/sha256_crypt/sha256_crypt.go
@@ -12,6 +12,7 @@ package sha256_crypt
 import (
 	"bytes"
 	"crypto/sha256"
+	"crypto/subtle"
 	"strconv"
 
 	"github.com/GehirnInc/crypt"
@@ -155,7 +156,7 @@ func (c *crypter) Verify(hashedKey string, key []byte) error {
 	if err != nil {
 		return err
 	}
-	if newHash != hashedKey {
+	if subtle.ConstantTimeCompare([]byte(newHash), []byte(hashedKey)) != 1 {
 		return crypt.ErrKeyMismatch
 	}
 	return nil

--- a/sha512_crypt/sha512_crypt.go
+++ b/sha512_crypt/sha512_crypt.go
@@ -12,6 +12,7 @@ package sha512_crypt
 import (
 	"bytes"
 	"crypto/sha512"
+	"crypto/subtle"
 	"strconv"
 
 	"github.com/GehirnInc/crypt"
@@ -170,7 +171,7 @@ func (c *crypter) Verify(hashedKey string, key []byte) error {
 	if err != nil {
 		return err
 	}
-	if newHash != hashedKey {
+	if subtle.ConstantTimeCompare([]byte(newHash), []byte(hashedKey)) != 1 {
 		return crypt.ErrKeyMismatch
 	}
 	return nil


### PR DESCRIPTION
This changes hash comparisons to use constant-time comparison operators
from Go's `subtle` package. It mitigates the risk of timing-based password
recovery attacks.